### PR TITLE
chore(deps): migrate to sypl v2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/thalesfsp/concurrentloop v1.3.5
 	github.com/thalesfsp/customerror v1.2.9
 	github.com/thalesfsp/status v1.0.19
-	github.com/thalesfsp/sypl v1.19.20
+	github.com/thalesfsp/sypl/v2 v2.0.0
 	github.com/thalesfsp/validation v0.0.3
 	go.elastic.co/apm v1.15.0
 )
@@ -43,6 +43,7 @@ require (
 	github.com/prometheus/procfs v0.15.1 // indirect
 	github.com/santhosh-tekuri/jsonschema v1.2.4 // indirect
 	github.com/thalesfsp/randomness v0.0.9 // indirect
+	github.com/thalesfsp/sypl v1.19.20 // indirect
 	go.elastic.co/fastjson v1.4.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
 	go.opentelemetry.io/otel v1.34.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -103,6 +103,8 @@ github.com/thalesfsp/status v1.0.19 h1:mCvizOEEI0mgcf9VL+brvdBUl4r/pDoPmxSsnFop7
 github.com/thalesfsp/status v1.0.19/go.mod h1:ZwlaaU4tPETPq/wf3bsS/sVqSQpMUPMK7iTqkSSJqVY=
 github.com/thalesfsp/sypl v1.19.20 h1:FcKm7x5Xx7k/5UPXysjELMQnpQ9x5xc9R6VzMKFH+EY=
 github.com/thalesfsp/sypl v1.19.20/go.mod h1:poTPF9XvuMAcZ1qnyLyUJhP9ivAyrODoKFMuDc/b6AU=
+github.com/thalesfsp/sypl/v2 v2.0.0 h1:sG8R5DPKpsbq0pF+jSlEy1XNYIrhTUbfwA1duLmq5/8=
+github.com/thalesfsp/sypl/v2 v2.0.0/go.mod h1:RCM1KBOet35pLWc6VPixSPPa5neyxaGJHGeRT5CEczY=
 github.com/thalesfsp/validation v0.0.3 h1:iXWXZLALIGUKJSxAeDt40kxUyzjeHeHc86f9fP9vin4=
 github.com/thalesfsp/validation v0.0.3/go.mod h1:0jwfQpbuzVJgVSPoiDJ7KCT76CLdMq4R++InC353SZ8=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/internal/customapm/error.go
+++ b/internal/customapm/error.go
@@ -6,9 +6,9 @@ import (
 	"expvar"
 
 	"github.com/thalesfsp/queue/internal/logging"
-	"github.com/thalesfsp/sypl"
-	"github.com/thalesfsp/sypl/fields"
-	"github.com/thalesfsp/sypl/level"
+	"github.com/thalesfsp/sypl/v2"
+	"github.com/thalesfsp/sypl/v2/fields"
+	"github.com/thalesfsp/sypl/v2/level"
 	"go.elastic.co/apm"
 )
 

--- a/internal/customapm/logger.go
+++ b/internal/customapm/logger.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 
 	"github.com/thalesfsp/queue/internal/logging"
-	"github.com/thalesfsp/sypl"
-	"github.com/thalesfsp/sypl/level"
+	"github.com/thalesfsp/sypl/v2"
+	"github.com/thalesfsp/sypl/v2/level"
 	"github.com/thalesfsp/validation"
 )
 

--- a/internal/logging/logging.go
+++ b/internal/logging/logging.go
@@ -4,12 +4,12 @@ import (
 	"context"
 	"sync"
 
-	"github.com/thalesfsp/sypl"
-	"github.com/thalesfsp/sypl/fields"
-	"github.com/thalesfsp/sypl/formatter"
-	"github.com/thalesfsp/sypl/level"
-	"github.com/thalesfsp/sypl/output"
-	"github.com/thalesfsp/sypl/processor"
+	"github.com/thalesfsp/sypl/v2"
+	"github.com/thalesfsp/sypl/v2/fields"
+	"github.com/thalesfsp/sypl/v2/formatter"
+	"github.com/thalesfsp/sypl/v2/level"
+	"github.com/thalesfsp/sypl/v2/output"
+	"github.com/thalesfsp/sypl/v2/processor"
 	"go.elastic.co/apm"
 )
 

--- a/queue/interface.go
+++ b/queue/interface.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"expvar"
 
-	"github.com/thalesfsp/sypl"
+	"github.com/thalesfsp/sypl/v2"
 )
 
 //////

--- a/queue/mock.go
+++ b/queue/mock.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"expvar"
 
-	"github.com/thalesfsp/sypl"
+	"github.com/thalesfsp/sypl/v2"
 )
 
 //////

--- a/queue/queue.go
+++ b/queue/queue.go
@@ -8,8 +8,8 @@ import (
 	"github.com/thalesfsp/queue/internal/logging"
 	"github.com/thalesfsp/queue/internal/metrics"
 	"github.com/thalesfsp/status"
-	"github.com/thalesfsp/sypl"
-	"github.com/thalesfsp/sypl/level"
+	"github.com/thalesfsp/sypl/v2"
+	"github.com/thalesfsp/sypl/v2/level"
 	"github.com/thalesfsp/validation"
 )
 

--- a/rabbitmq/rabbitmq.go
+++ b/rabbitmq/rabbitmq.go
@@ -10,9 +10,9 @@ import (
 	"github.com/thalesfsp/queue/internal/logging"
 	"github.com/thalesfsp/queue/queue"
 	"github.com/thalesfsp/status"
-	"github.com/thalesfsp/sypl"
-	"github.com/thalesfsp/sypl/fields"
-	"github.com/thalesfsp/sypl/level"
+	"github.com/thalesfsp/sypl/v2"
+	"github.com/thalesfsp/sypl/v2/fields"
+	"github.com/thalesfsp/sypl/v2/level"
 	"github.com/thalesfsp/validation"
 )
 


### PR DESCRIPTION
## What

Migrate `queue` to **sypl v2** (`github.com/thalesfsp/sypl/v2 v2.0.0`).

## Why

sypl v2 moves the module to the `/v2` path and isolates ElasticSearch into a separate `es/v2` submodule so the core module no longer drags in `go-elasticsearch`.

## Scope — import paths only

`queue` uses only `output.Console` for logging. It has:
- **No** ElasticSearch usage (the one `ElasticSearch` mention is a prose comment),
- **No** removed v1 APIs (`SetName`/`GetProcessor`/`SetContent`/`SetLevel`/`AnyMaxLevel`/`SetBuiltinLogger`),
- **No** use of the `Warn`/`Info` levels whose numeric ordering changed (only `Error`/`Fatal`/`Debug` are referenced).

So the change is a pure import-path rewrite (`github.com/thalesfsp/sypl` → `github.com/thalesfsp/sypl/v2`) across 7 files, plus the `go.mod`/`go.sum` update.

## Dependency note

The direct dependency on sypl v1 is dropped. It remains in `go.mod` as an **indirect** dependency because `github.com/thalesfsp/concurrentloop` still targets v1 — nothing in this repo's own code references it.

## Verification (local, macOS)

- `go build ./...` — clean
- `go vet ./...` — clean
- `make test` (`go test -short -race -cover ./...`) — **Test OK**, identical to the pre-migration baseline on `main` (rabbitmq e2e test skips as it requires the integration environment).